### PR TITLE
fix link origin and mac incompatible option on ln command

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 source venv/bin/activate
 pip install -r requirements.txt
-ln -sfT settings.py settings_test.py
+ln -sf dashboard/dev_settings_test.py settings_test.py
 rm -rf build/junit.xml
 CONFIG_FILE="test" python -m pytest --junitxml build/junit.xml dashboard/


### PR DESCRIPTION
@giorgiosironi - When I run ln -sfT on my mac I get "ln: illegal option -- T"; so I removed it. Also, the link should come from dashboard dashboard/dev_settings_test.py and not settings.py 

If you are ok with that could you please merge this ticket? I will be on holiday so won't see your reply within 2 weeks. Thanks.

I will also add an improvement on the description on Readme to say that if someone wants to run the tests in their machine they need to have postgres running.