### PR TITLE
Replace db drop with clean in tests

### DIFF
--- a/dashboard/tests/test_database.py
+++ b/dashboard/tests/test_database.py
@@ -1,6 +1,7 @@
 import psycopg2
 from config_decider import config as settings
 
+from dashboard.models.articles import clean
 
 def test_database_setup():
     conn = psycopg2.connect(dbname='postgres',
@@ -8,14 +9,7 @@ def test_database_setup():
                            host=settings.host,
                            password=settings.password)
     conn.set_isolation_level(0)
-    cur = conn.cursor()
-    cur.execute("SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '" + settings.database + "' AND pid <> pg_backend_pid();")
-    conn.commit()
-    cur.execute("DROP DATABASE IF EXISTS " + settings.database + ";")
-    conn.commit()
-    cur.execute("CREATE DATABASE " + settings.database + ";")
-    conn.commit()
-    cur.close()
+    clean()
     conn.close()
 
 
@@ -25,8 +19,7 @@ def test_database_destroy():
                            host=settings.host,
                            password=settings.password)
     conn.set_isolation_level(0)
-    cur = conn.cursor()
-    cur.execute("DROP DATABASE IF EXISTS " + settings.database + ";")
+    clean()
     conn.commit()
 
 

--- a/dashboard/tests/test_process_dashboard_queue_tests.py
+++ b/dashboard/tests/test_process_dashboard_queue_tests.py
@@ -168,9 +168,8 @@ class TestProcessDashboardQueue(unittest.TestCase):
     def test_process_event_message_exception(self, mock_logger_exception):
         fake_logger = FakeLogger()
         mock_logger_exception.side_effect = fake_logger.exception
-        message = message_from_process_event_message
+        message = {}  # pass in bad message
         process_dashboard_queue.process_event_message(message)
-        self.assertRaises(Exception)
         self.assertEqual("Error processing event message: %s", fake_logger.logexception)
 
     def _process_property_message(self, message):


### PR DESCRIPTION
This is required to stop the db being dropped after tests complete, therefore not allowing other suites to run without creating the db from scratch.