### PR TITLE
Handle incorrect publication status reporting on latest articles

### DIFF
--- a/dashboard_2/articles/models.py
+++ b/dashboard_2/articles/models.py
@@ -509,13 +509,16 @@ class PropertyFinderManager(models.Manager):
         of 'publication-status' and not having the value 'hidden' or 'published'
         """
 
-        articles = self.model.objects\
+        pub_states = self.model.objects \
             .filter(self.Q_FIND_PUB_STATUS) \
-            .exclude(self.Q_FIND_PUBLISHED | self.Q_FIND_HIDDEN | self.Q_FIND_NULL) \
-            .values_list('article__article_identifier', flat=True)
+            .exclude(self.Q_FIND_PUBLISHED | self.Q_FIND_HIDDEN | self.Q_FIND_NULL)
+
+        # check that property.article latest version matches current property version
+        # else could be an old property duplicate e.g. an article could have x3 `publication-status` entries
 
         # extract unique article identifiers
-        return {article for article in articles}
+        return {prop.article.article_identifier for prop in pub_states
+                if prop.version == Article.versions.latest(prop.article.article_identifier)}
 
     def preview_link(self, article_id: str = None, properties: List['Property'] = None) -> Dict[str, str]:
         """Generate a preview_link string including a base url and a `Property` of name 'path'.

--- a/dashboard_2/articles/tests/test_api_views.py
+++ b/dashboard_2/articles/tests/test_api_views.py
@@ -50,7 +50,11 @@ def test_can_find_article_with_in_progress_status(mock_scheduler: MagicMock,
                                                   article: Article,
                                                   client: Client,
                                                   events_for_09003: List[Event],
-                                                  properties_v1: List[Property]):
+                                                  properties_v1: List[Property],
+                                                  property_publication_status_v2: Property):
+    property_publication_status_v2.text_value = 'publication in progress'
+    property_publication_status_v2.save()
+
     response = client.get('/api/current')
     assert response.status_code == 200
     assert len(response.data['in-progress']) == 1


### PR DESCRIPTION
Previously, if an article had multiple `publication-status` properties there was a condition that could be hit where you returned one from an early article version. This prevents this.