### PR TITLE
Handle large `/api/current` queries better

### DIFF
--- a/dashboard_2/articles/api.py
+++ b/dashboard_2/articles/api.py
@@ -34,11 +34,11 @@ class CurrentArticlesAPIView(APIView):
             'uir': []
         }
 
-        latest_article_ids = Property.find.latest_articles()
+        latest_article_map = Property.find.latest_articles()
 
-        current_articles = Article.details.get_details_for_articles(latest_article_ids)
+        current_articles = Article.details.get_details_for_articles(article_map=latest_article_map)
 
-        current_schedules = get_scheduled_statuses(list(latest_article_ids)).get('articles', [])
+        current_schedules = get_scheduled_statuses(list(latest_article_map)).get('articles', [])
 
         # filter for actual scheduled articles that are not yet published
         current_schedules = [a for a in current_schedules if a.get('scheduled') and not a.get('published')]

--- a/dashboard_2/articles/tests/test_api_views.py
+++ b/dashboard_2/articles/tests/test_api_views.py
@@ -213,7 +213,8 @@ def test_can_schedule_an_article(mock_scheduler: MagicMock, api_client: APIClien
 @pytest.mark.django_db
 @patch('articles.api.scheduled_statuses_for_range')
 def test_can_get_schedules_for_range(mock_scheduler: MagicMock,
-                                     article_complete: Article, api_client: APIClient):
+                                     article_complete: Article,
+                                     api_client: APIClient):
     mock_data = {
         "articles": [
             {

--- a/dashboard_2/articles/tests/test_property_model.py
+++ b/dashboard_2/articles/tests/test_property_model.py
@@ -1,5 +1,10 @@
+from typing import List
+
 import pytest
-from articles.models import Article, Property
+
+from articles.models import (
+    Article, Event, Property
+)
 
 
 @pytest.mark.django_db
@@ -18,7 +23,9 @@ def test_can_delete_property(property_doi_v1: Property):
 
 
 @pytest.mark.django_db
-def test_can_get_latest_article_ids_excluding_published_articles(article: Article, properties_v1: Property):
+def test_can_get_latest_article_ids_excluding_published_articles(article: Article,
+                                                                 events_for_09003: List[Event],
+                                                                 properties_v1: Property, ):
     # create an 'already published' article
     article_2 = Article.objects.create(article_identifier='01234')
 
@@ -36,7 +43,9 @@ def test_can_get_latest_article_ids_excluding_published_articles(article: Articl
 
 
 @pytest.mark.django_db
-def test_can_get_latest_article_ids_excluding_hidden_articles(article: Article, properties_v1: Property):
+def test_can_get_latest_article_ids_excluding_hidden_articles(article: Article,
+                                                              events_for_09003: List[Event],
+                                                              properties_v1: Property):
     # create an 'already published' article
     article_2 = Article.objects.create(article_identifier='01234')
 


### PR DESCRIPTION
- Removes some query duplication
- Passes existing data where possible instead of re requesting it