### PR TITLE
quieten dashboard errors

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from config_decider import config as settings
-from flask import Flask, redirect, url_for, render_template, request, jsonify
+from flask import Flask, redirect, url_for, render_template, request, Response, jsonify
 from flask_cors import CORS
 from flask_session import Session
 from models import article_adapters, article_operations, articles
@@ -49,7 +49,10 @@ def detail_page(article_id, version=None, run_id=None):
 
 @app.route('/api/article/<article_id>')
 def detail(article_id):
-    return jsonify(article_adapters.get_detail_article_model(article_id))
+    article = article_adapters.get_detail_article_model(article_id)
+    if not article:
+        return Response(status=404)
+    return jsonify(article)
 
 
 @app.route('/api/queue_article_publication', methods=['POST'])

--- a/dashboard/models/article_adapters.py
+++ b/dashboard/models/article_adapters.py
@@ -116,6 +116,8 @@ def get_detail_article_model(article_id):
 
     article = get_article(article_id)
     logging.debug("article data %s", str(article))
+    if not article:
+        return
 
     model = {'id': article['article-identifier']}
     versions = article.get('versions')


### PR DESCRIPTION
ticket here: https://github.com/elifesciences/jira-import/issues/460

* detail view now returns a 404 when article not found instead of a 5xx and a stack trace in the log

This should finally quieten those daily 500 errors.