### PR TITLE
Smoke test article scheduler

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -ex
 
-[ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname):8081/api/current) == 200 ]
+# elife-article-scheduler
+[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080) == 200 ]

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ex
 
+# elife-dashboard
+[ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname):8081/api/current) == 200 ]
+
 # elife-article-scheduler
-[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080) == 200 ]
+[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080/schedule/ping) == 200 ]


### PR DESCRIPTION
Removes test for dashboard_2 which has never been used, adds one for elife-article-scheduler