### PR TITLE
py2 removal

### DIFF
--- a/README-Frontend.md
+++ b/README-Frontend.md
@@ -37,7 +37,7 @@ These requirements are for the front end only, additional requirements can be fo
 * In the root of the project folder create your virtual environment and activate it. This step will only need to be done once, the [aliases](#aliases) will do this for you in the future.
 
 ```bash
-virtualenv venv
+python3 -m venv venv
 source venv/bin/activate
 ```  
   

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The instructions below are for Mac OS and may need to be adapted for other platf
 * Create virtual environment, you will only need to do this once. In the project folder run:
 
 ```bash
-virtualenv venv
+python3 -m venv venv
 ```
 * Activate the virtual environment
 
@@ -79,7 +79,7 @@ cd /srv/elife-dashboard
 **Create environment**
 
 ```bash
-virtualenv venv
+python3 -m venv venv
 ```
 
 **Activate environment**

--- a/dashboard_2/README.md
+++ b/dashboard_2/README.md
@@ -30,7 +30,7 @@ The instructions below are for Mac OS and may need to be adapted for other platf
 * Create virtual environment, you will only need to do this once. In the project folder run:
 
 ```bash
-virtualenv venv --python=3.5
+python3 -m venv venv
 ```
 * Activate the virtual environment
 


### PR DESCRIPTION
* readme, replaces 'virtualenv' invocations with 'python3 -m venv venv

"virtualenv" invocation without qualification is ambiguous as it will default to python2 if installed with `pip` rather than `pip3`