### PR TITLE
deps, replaces nested word-wrap with an alternative.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9642,7 +9642,7 @@
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "word-wrap": "npm:@aashutoshrathi/word-wrap"
       }
     },
     "os-browserify": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "underscore": "^1.12",
     "uniq": "^1.0"
   },
+  "overrides": {
+    "word-wrap" : "npm:@aashutoshrathi/word-wrap"
+  },
   "browserify": {
     "transform": [
       [


### PR DESCRIPTION
the alternative repo seems to be recommended in the issue tracker for word-wrap because word-wrap is dead. alternative repo is 9 commits ahead with nothing nefarious going on.